### PR TITLE
[Breaking] Rename `to_not_raise` to `to_raise_nothing`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- [Breaking] Rename `to_not_raise` to `to_raise_nothing`.
 - Add `to_match` matcher.
 
 ## 0.4.0

--- a/lib/easytest.rb
+++ b/lib/easytest.rb
@@ -22,8 +22,8 @@ require_relative "easytest/matcher/instance_of"
 require_relative "easytest/matcher/kind_of"
 require_relative "easytest/matcher/match"
 require_relative "easytest/matcher/nil"
-require_relative "easytest/matcher/not_raise"
 require_relative "easytest/matcher/raise"
+require_relative "easytest/matcher/raise_nothing"
 require_relative "easytest/matcher/true"
 
 module Easytest

--- a/lib/easytest/expectation.rb
+++ b/lib/easytest/expectation.rb
@@ -47,16 +47,16 @@ module Easytest
 
     def to_raise(expected)
       raise FatalError, "`to_raise` requires a block like `expect { ... }.to_raise`" unless block
-      raise FatalError, "`not.to_raise` can cause a false positive, so use `to_not_raise` instead" if negate?
+      raise FatalError, "`not.to_raise` can cause a false positive, so use `to_raise_nothing` instead" if negate?
       raise FatalError, "`to_raise` requires a Class, String, or Regexp" unless [Class, String, Regexp].any? { expected.is_a? _1 }
 
       Matcher::Raise.new(actual: block, expected: expected, negate: negate).match!
     end
 
-    def to_not_raise
-      raise FatalError, "`to_not_raise` requires a block like `expect { ... }.to_not_raise`" unless block
+    def to_raise_nothing
+      raise FatalError, "`to_raise_nothing` requires a block like `expect { ... }.to_raise_nothing`" unless block
 
-      Matcher::NotRaise.new(actual: block).match!
+      Matcher::RaiseNothing.new(actual: block).match!
     end
 
     private

--- a/lib/easytest/matcher/raise_nothing.rb
+++ b/lib/easytest/matcher/raise_nothing.rb
@@ -1,6 +1,6 @@
 module Easytest
   module Matcher
-    class NotRaise < Base
+    class RaiseNothing < Base
       def initialize(actual:)
         super(actual: actual, expected: nil)
       end
@@ -20,7 +20,7 @@ module Easytest
       end
 
       def message
-        "not raise"
+        "raise nothing"
       end
     end
   end

--- a/sig/easytest.rbs
+++ b/sig/easytest.rbs
@@ -24,7 +24,7 @@ module Easytest
     def to_match: (untyped expected) -> void
 
     def to_raise: ((Class | String | Regexp) expected) -> void
-    def to_not_raise: () -> void
+    def to_raise_nothing: () -> void
   end
 end
 

--- a/test/expectation_test.rb
+++ b/test/expectation_test.rb
@@ -7,113 +7,113 @@ def subject(actual)
 end
 
 test "to_eq" do
-  expect { subject("foo").to_eq("foo") }.to_not_raise
+  expect { subject("foo").to_eq("foo") }.to_raise_nothing
   expect { subject("foo").to_eq("bar") }.to_raise "equal"
 end
 
 test "not.to_eq" do
-  expect { subject("foo").not.to_eq("bar") }.to_not_raise
+  expect { subject("foo").not.to_eq("bar") }.to_raise_nothing
   expect { subject("foo").not.to_eq("foo") }.to_raise "not equal"
 end
 
 test "to_equal" do
-  expect { subject(1).to_equal(1) }.to_not_raise
+  expect { subject(1).to_equal(1) }.to_raise_nothing
   expect { subject(1).to_equal(0) }.to_raise "equal"
 end
 
 test "to_be" do
-  expect { subject(true).to_be(true) }.to_not_raise
+  expect { subject(true).to_be(true) }.to_raise_nothing
   expect { subject(true).to_be(false) }.to_raise "same"
 end
 
 test "not.to_be" do
-  expect { subject(true).not.to_be(false) }.to_not_raise
+  expect { subject(true).not.to_be(false) }.to_raise_nothing
   expect { subject(true).not.to_be(true) }.to_raise "not same"
 end
 
 test "to_be_nil" do
-  expect { subject(nil).to_be_nil }.to_not_raise
+  expect { subject(nil).to_be_nil }.to_raise_nothing
   expect { subject(false).to_be_nil }.to_raise "nil"
 end
 
 test "not.to_be_nil" do
-  expect { subject(false).not.to_be_nil }.to_not_raise
+  expect { subject(false).not.to_be_nil }.to_raise_nothing
   expect { subject(nil).not.to_be_nil }.to_raise "not nil"
 end
 
 test "to_be_true" do
-  expect { subject(true).to_be_true }.to_not_raise
+  expect { subject(true).to_be_true }.to_raise_nothing
   expect { subject(false).to_be_true }.to_raise "true"
 end
 
 test "not.to_be_true" do
-  expect { subject(false).not.to_be_true }.to_not_raise
+  expect { subject(false).not.to_be_true }.to_raise_nothing
   expect { subject(true).not.to_be_true }.to_raise "not true"
 end
 
 test "to_be_false" do
-  expect { subject(false).to_be_false }.to_not_raise
+  expect { subject(false).to_be_false }.to_raise_nothing
   expect { subject(true).to_be_false }.to_raise "false"
 end
 
 test "not.to_be_false" do
-  expect { subject(true).not.to_be_false }.to_not_raise
+  expect { subject(true).not.to_be_false }.to_raise_nothing
   expect { subject(false).not.to_be_false }.to_raise "not false"
 end
 
 test "to_be_a" do
-  expect { subject("foo").to_be_a String }.to_not_raise
+  expect { subject("foo").to_be_a String }.to_raise_nothing
   expect { subject("foo").to_be_a Integer }.to_raise "be a"
 end
 
 test "not.to_be_a" do
-  expect { subject("foo").not.to_be_a Integer }.to_not_raise
+  expect { subject("foo").not.to_be_a Integer }.to_raise_nothing
   expect { subject("foo").not.to_be_a String }.to_raise "not be a"
 end
 
 test "to_be_kind_of" do
-  expect { subject("foo").to_be_kind_of String }.to_not_raise
+  expect { subject("foo").to_be_kind_of String }.to_raise_nothing
   expect { subject("foo").to_be_kind_of Integer }.to_raise "kind of"
 end
 
 test "not.to_be_kind_of" do
-  expect { subject("foo").not.to_be_kind_of Integer }.to_not_raise
+  expect { subject("foo").not.to_be_kind_of Integer }.to_raise_nothing
   expect { subject("foo").not.to_be_kind_of String }.to_raise "not kind of"
 end
 
 test "to_be_instance_of" do
-  expect { subject("foo").to_be_instance_of String }.to_not_raise
+  expect { subject("foo").to_be_instance_of String }.to_raise_nothing
   expect { subject("foo").to_be_instance_of Object }.to_raise "instance of"
 end
 
 test "not.to_be_instance_of" do
-  expect { subject("foo").not.to_be_instance_of Object }.to_not_raise
+  expect { subject("foo").not.to_be_instance_of Object }.to_raise_nothing
   expect { subject("foo").not.to_be_instance_of String }.to_raise "not instance of"
 end
 
 test "to_include" do
-  expect { subject("foo").to_include "f" }.to_not_raise
+  expect { subject("foo").to_include "f" }.to_raise_nothing
   expect { subject("foo").to_include "b" }.to_raise "include"
 
-  expect { subject(["foo"]).to_include "foo" }.to_not_raise
+  expect { subject(["foo"]).to_include "foo" }.to_raise_nothing
   expect { subject(["foo"]).to_include "bar" }.to_raise "include"
 end
 
 test "not.to_include" do
-  expect { subject("foo").not.to_include "b" }.to_not_raise
+  expect { subject("foo").not.to_include "b" }.to_raise_nothing
   expect { subject("foo").not.to_include "f" }.to_raise "not include"
 end
 
 test "to_match" do
-  expect { subject("foo").to_match %r{f} }.to_not_raise
+  expect { subject("foo").to_match %r{f} }.to_raise_nothing
   expect { subject("foo").to_match %r{b} }.to_raise "match"
 
-  expect { subject(/^fo/).to_match "foo" }.to_not_raise
+  expect { subject(/^fo/).to_match "foo" }.to_raise_nothing
   expect { subject(/^fo/).to_match "bar" }.to_raise "match"
 end
 
 test "not.to_match" do
-  expect { subject("foo").not.to_match %r{b} }.to_not_raise
+  expect { subject("foo").not.to_match %r{b} }.to_raise_nothing
   expect { subject("foo").not.to_match %r{f} }.to_raise "not match"
 end
 
@@ -125,28 +125,28 @@ raise_thing = -> { raise "foo" }
 noop = -> {}
 
 test "to_raise" do
-  expect { subject_block(&raise_thing).to_raise RuntimeError }.to_not_raise
+  expect { subject_block(&raise_thing).to_raise RuntimeError }.to_raise_nothing
   expect { subject_block(&noop).to_raise RuntimeError }.to_raise "raise"
 
-  expect { subject_block(&raise_thing).to_raise "foo" }.to_not_raise
+  expect { subject_block(&raise_thing).to_raise "foo" }.to_raise_nothing
   expect { subject_block(&noop).to_raise "bar" }.to_raise "raise"
 
-  expect { subject_block(&raise_thing).to_raise %r{fo} }.to_not_raise
+  expect { subject_block(&raise_thing).to_raise %r{fo} }.to_raise_nothing
   expect { subject_block(&noop).to_raise %r{ba} }.to_raise "raise"
 
   expect { subject("foo").to_raise "foo" }.to_raise "`to_raise` requires a block like `expect { ... }.to_raise`"
-  expect { subject_block(&noop).not.to_raise "foo" }.to_raise "`not.to_raise` can cause a false positive, so use `to_not_raise` instead"
+  expect { subject_block(&noop).not.to_raise "foo" }.to_raise "`not.to_raise` can cause a false positive, so use `to_raise_nothing` instead"
   expect { subject_block(&noop).to_raise 123 }.to_raise "`to_raise` requires a Class, String, or Regexp"
 end
 
 test "not.to_raise" do
   expect { subject_block(&noop).not.to_raise "anything" }
-    .to_raise "`not.to_raise` can cause a false positive, so use `to_not_raise` instead"
+    .to_raise "`not.to_raise` can cause a false positive, so use `to_raise_nothing` instead"
 end
 
-test "to_not_raise" do
-  expect { subject_block(&noop).to_not_raise }.to_not_raise
-  expect { subject_block(&raise_thing).to_not_raise }.to_raise "not raise"
+test "to_raise_nothing" do
+  expect { subject_block(&noop).to_raise_nothing }.to_raise_nothing
+  expect { subject_block(&raise_thing).to_raise_nothing }.to_raise "raise nothing"
 
-  expect { subject("foo").to_not_raise }.to_raise "`to_not_raise` requires a block like `expect { ... }.to_not_raise`"
+  expect { subject("foo").to_raise_nothing }.to_raise "`to_raise_nothing` requires a block like `expect { ... }.to_raise_nothing`"
 end

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -15,7 +15,7 @@ test "simple case" do
   expect({ a: 1 }).to_include :a
   expect(/^fo/).to_match "foo"
   expect { 1 / 0 }.to_raise ZeroDivisionError
-  expect { 1 / 2 }.to_not_raise
+  expect { 1 / 2 }.to_raise_nothing
 end
 
 test "add something later"


### PR DESCRIPTION
Respect the unified naming not to use the `not` word; for consistency.