### PR TITLE
[Breaking] Change refinement to `extend` in an anonymous module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## 0.10.0
 
-- **[Breaking]** Change refinement to `include` in an anonymous module.
-  The usage should change as follows:
+- **[Breaking]** Change refinement to `include` in an anonymous module. The usage should change as follows:
 
 ```diff
 -using Easytest::DSL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## 0.10.0
 
-- **[Breaking]** Change refinement to `include` in an anonymous module. The usage should change as follows:
+- **[Breaking]** Change refinement to `extend` in an anonymous module. The usage should change as follows:
 
 ```diff
 -using Easytest::DSL
-+include Easytest::DSL
++extend Easytest::DSL
 ```
 
 ## 0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.10.0
+
+- **[Breaking]** Change refinement to `include` in an anonymous module.
+  The usage should change as follows:
+
+```diff
+-using Easytest::DSL
++include Easytest::DSL
+```
+
 ## 0.9.0
 
 - Add watch mode (`--watch`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## 0.10.0
+## Head
 
 - **[Breaking]** Change refinement to `extend` in an anonymous module. The usage should change as follows:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First, put `test/addition_test.rb` as below:
 ```ruby
 require "easytest"
 
-using Easytest::DSL
+include Easytest::DSL
 
 test "addition" do
   expect(1 + 2).to_eq 2

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ First, put `test/addition_test.rb` as below:
 ```ruby
 require "easytest"
 
-include Easytest::DSL
+extend Easytest::DSL
 
 test "addition" do
   expect(1 + 2).to_eq 2

--- a/lib/easytest/cli.rb
+++ b/lib/easytest/cli.rb
@@ -112,7 +112,11 @@ module Easytest
         .filter do |file|
           argv.empty? || argv.any? { |pattern| file.include?(pattern) }
         end
-        .each { |test_file| load test_file }
+        .each { load_test_file(_1) }
+    end
+
+    def load_test_file(file)
+      load(file, true)
     end
 
     def test_files
@@ -129,9 +133,7 @@ module Easytest
       require "listen"
       listener = Listen.to(Easytest.test_dir, only: /_test\.rb$/) do |modified, added|
         Easytest.start(no_tests_forbidden: false)
-        test_files.intersection(modified + added).each do |file|
-          load(file)
-        end
+        test_files.intersection(modified + added).each { load_test_file(_1) }
         Easytest.run
       end
       listener.start

--- a/lib/easytest/dsl.rb
+++ b/lib/easytest/dsl.rb
@@ -1,32 +1,30 @@
 module Easytest
   module DSL
-    refine Kernel do
-      def test(name, &block)
-        Utils.raise_if_no_test_name(name, method: "test")
-        Easytest.add_case Case.new(name: name, block: block)
-      end
+    def test(name, &block)
+      Utils.raise_if_no_test_name(name, method: "test")
+      Easytest.add_case Case.new(name: name, block: block)
+    end
 
-      def before(&block)
-        Easytest.add_hook Hook.new(type: :before, block: block)
-      end
+    def before(&block)
+      Easytest.add_hook Hook.new(type: :before, block: block)
+    end
 
-      def after(&block)
-        Easytest.add_hook Hook.new(type: :after, block: block)
-      end
+    def after(&block)
+      Easytest.add_hook Hook.new(type: :after, block: block)
+    end
 
-      def skip(name, &block)
-        Utils.raise_if_no_test_name(name, method: "skip")
-        Easytest.add_case Case.new(name: name, skipped: true, block: block)
-      end
+    def skip(name, &block)
+      Utils.raise_if_no_test_name(name, method: "skip")
+      Easytest.add_case Case.new(name: name, skipped: true, block: block)
+    end
 
-      def only(name, &block)
-        Utils.raise_if_no_test_name(name, method: "only")
-        Easytest.add_case Case.new(name: name, only: true, block: block)
-      end
+    def only(name, &block)
+      Utils.raise_if_no_test_name(name, method: "only")
+      Easytest.add_case Case.new(name: name, only: true, block: block)
+    end
 
-      def expect(actual = nil, &block)
-        Expectation.new(actual, &block)
-      end
+    def expect(actual = nil, &block)
+      Expectation.new(actual, &block)
     end
   end
 end

--- a/sig-private/easytest/cli.rbs
+++ b/sig-private/easytest/cli.rbs
@@ -28,6 +28,8 @@ module Easytest
 
     def setup: () -> void
 
+    def load_test_file: (String file) -> void
+
     def test_files: () -> Array[String]
 
     def watch?: () -> bool

--- a/sig/easytest.rbs
+++ b/sig/easytest.rbs
@@ -5,6 +5,23 @@ module Easytest
 
   # Define methods for the Easytest DSL.
   module DSL
+    def test: (String name) ?{ () -> void } -> void
+
+    # Run the given block before each test case.
+    def before: () { (Easytest::Case case) -> void } -> void
+
+    # Run the given block after each test case.
+    def after: () { (Easytest::Case case) -> void } -> void
+
+    # Skip the given test case.
+    def skip: (String name) { () -> void } -> void
+
+    # Run only the given test case.
+    def only: (String name) { () -> void } -> void
+
+    # Expect the given object or block to satisfy some criterion.
+    def expect: (untyped actual) -> Easytest::Expectation
+              | { () -> void } -> Easytest::Expectation
   end
 
   # An expectation in test cases.
@@ -68,25 +85,4 @@ module Easytest
     # A test case name.
     attr_reader name: String
   end
-end
-
-module Kernel
-  # TODO: Can we avoid `RBS::DuplicatedMethodDefinitionError` "::Kernel#test has duplicated definitions"?
-  # def test: (String name) ?{ () -> void } -> void
-
-  # Run the given block before each test case.
-  def before: () { (Easytest::Case case) -> void } -> void
-
-  # Run the given block after each test case.
-  def after: () { (Easytest::Case case) -> void } -> void
-
-  # Skip the given test case.
-  def skip: (String name) { () -> void } -> void
-
-  # Run only the given test case.
-  def only: (String name) { () -> void } -> void
-
-  # Expect the given object or block to satisfy some criterion.
-  def expect: (untyped actual) -> Easytest::Expectation
-            | { () -> void } -> Easytest::Expectation
 end

--- a/sig/easytest.rbs
+++ b/sig/easytest.rbs
@@ -5,6 +5,7 @@ module Easytest
 
   # Define methods for the Easytest DSL.
   module DSL
+    # Define a test case. If omitting a block, the case is considered a to-do.
     def test: (String name) ?{ () -> void } -> void
 
     # Run the given block before each test case.

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -1,63 +1,4 @@
 ---
-- file: lib/easytest/dsl.rb
-  diagnostics:
-  - range:
-      start:
-        line: 4
-        character: 10
-      end:
-        line: 4
-        character: 14
-    severity: ERROR
-    message: |-
-      Cannot allow method body have type `void` because declared as type `(::TrueClass | ::FalseClass | ::Time | nil | ::Integer)`
-        void <: (::TrueClass | ::FalseClass | ::Time | nil | ::Integer)
-          void <: ::TrueClass
-    code: Ruby::MethodBodyTypeMismatch
-  - range:
-      start:
-        line: 4
-        character: 14
-      end:
-        line: 4
-        character: 28
-    severity: ERROR
-    message: Method parameters are incompatible with declaration `((::String | ::Integer),
-      (::String | ::IO), ?(::String | ::IO)) -> (::TrueClass | ::FalseClass | ::Time
-      | nil | ::Integer)`
-    code: Ruby::MethodArityMismatch
-  - range:
-      start:
-        line: 5
-        character: 36
-      end:
-        line: 5
-        character: 40
-    severity: ERROR
-    message: |-
-      Cannot pass a value of type `(::String | ::Integer)` as an argument of type `::String`
-        (::String | ::Integer) <: ::String
-          ::Integer <: ::String
-            ::Numeric <: ::String
-              ::Object <: ::String
-                ::BasicObject <: ::String
-    code: Ruby::ArgumentTypeMismatch
-  - range:
-      start:
-        line: 6
-        character: 41
-      end:
-        line: 6
-        character: 45
-    severity: ERROR
-    message: |-
-      Cannot pass a value of type `(::String | ::Integer)` as an argument of type `::String`
-        (::String | ::Integer) <: ::String
-          ::Integer <: ::String
-            ::Numeric <: ::String
-              ::Object <: ::String
-                ::BasicObject <: ::String
-    code: Ruby::ArgumentTypeMismatch
 - file: test/smoke_test.rb
   diagnostics:
   - range:
@@ -66,9 +7,9 @@
         character: 0
       end:
         line: 3
-        character: 5
+        character: 7
     severity: ERROR
-    message: Type `::Object` does not have method `using`
+    message: Type `::Object` does not have method `include`
     code: Ruby::NoMethod
   - range:
       start:
@@ -92,6 +33,206 @@
     code: Ruby::UnexpectedBlockGiven
   - range:
       start:
+        line: 6
+        character: 2
+      end:
+        line: 6
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 7
+        character: 2
+      end:
+        line: 7
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 8
+        character: 2
+      end:
+        line: 8
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 9
+        character: 2
+      end:
+        line: 9
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 10
+        character: 2
+      end:
+        line: 10
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 11
+        character: 2
+      end:
+        line: 11
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 12
+        character: 2
+      end:
+        line: 12
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 13
+        character: 2
+      end:
+        line: 13
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 14
+        character: 2
+      end:
+        line: 14
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 15
+        character: 2
+      end:
+        line: 15
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 16
+        character: 2
+      end:
+        line: 16
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 17
+        character: 2
+      end:
+        line: 17
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 18
+        character: 2
+      end:
+        line: 18
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 19
+        character: 2
+      end:
+        line: 19
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 20
+        character: 2
+      end:
+        line: 20
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 21
+        character: 2
+      end:
+        line: 21
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 22
+        character: 2
+      end:
+        line: 22
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 23
+        character: 2
+      end:
+        line: 23
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 26
+        character: 0
+      end:
+        line: 26
+        character: 6
+    severity: ERROR
+    message: Type `::Object` does not have method `before`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 30
+        character: 0
+      end:
+        line: 30
+        character: 5
+    severity: ERROR
+    message: Type `::Object` does not have method `after`
+    code: Ruby::NoMethod
+  - range:
+      start:
         line: 34
         character: 0
       end:
@@ -100,3 +241,43 @@
     severity: ERROR
     message: More positional arguments are required
     code: Ruby::InsufficientPositionalArguments
+  - range:
+      start:
+        line: 36
+        character: 0
+      end:
+        line: 36
+        character: 4
+    severity: ERROR
+    message: Type `::Object` does not have method `skip`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 37
+        character: 2
+      end:
+        line: 37
+        character: 8
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 41
+        character: 2
+      end:
+        line: 41
+        character: 6
+    severity: ERROR
+    message: Type `::Object` does not have method `only`
+    code: Ruby::NoMethod
+  - range:
+      start:
+        line: 42
+        character: 4
+      end:
+        line: 42
+        character: 10
+    severity: ERROR
+    message: Type `::Object` does not have method `expect`
+    code: Ruby::NoMethod

--- a/steep_expectations.yml
+++ b/steep_expectations.yml
@@ -3,16 +3,6 @@
   diagnostics:
   - range:
       start:
-        line: 3
-        character: 0
-      end:
-        line: 3
-        character: 7
-    severity: ERROR
-    message: Type `::Object` does not have method `include`
-    code: Ruby::NoMethod
-  - range:
-      start:
         line: 5
         character: 0
       end:

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -3,7 +3,7 @@ require "open3"
 require "pathname"
 require "tempfile"
 
-include Easytest::DSL
+extend Easytest::DSL
 
 def run(cmd)
   stdout, stderr, status = Open3.capture3(cmd)

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -3,7 +3,7 @@ require "open3"
 require "pathname"
 require "tempfile"
 
-using Easytest::DSL
+include Easytest::DSL
 
 def run(cmd)
   stdout, stderr, status = Open3.capture3(cmd)

--- a/test/expectation_test.rb
+++ b/test/expectation_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-using Easytest::DSL
+include Easytest::DSL
 
 def subject(actual)
   Easytest::Expectation.new(actual)

--- a/test/expectation_test.rb
+++ b/test/expectation_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-include Easytest::DSL
+extend Easytest::DSL
 
 def subject(actual)
   Easytest::Expectation.new(actual)

--- a/test/fixtures/hooks.rb
+++ b/test/fixtures/hooks.rb
@@ -1,5 +1,5 @@
 require "easytest"
-include Easytest::DSL
+extend Easytest::DSL
 
 count = { before: 0, after: 0, names: [] }
 

--- a/test/fixtures/hooks.rb
+++ b/test/fixtures/hooks.rb
@@ -1,5 +1,5 @@
 require "easytest"
-using Easytest::DSL
+include Easytest::DSL
 
 count = { before: 0, after: 0, names: [] }
 

--- a/test/fixtures/run_only_case.rb
+++ b/test/fixtures/run_only_case.rb
@@ -1,5 +1,5 @@
 require "easytest"
-include Easytest::DSL
+extend Easytest::DSL
 
 test "should not run this case" do
   raise

--- a/test/fixtures/run_only_case.rb
+++ b/test/fixtures/run_only_case.rb
@@ -1,5 +1,5 @@
 require "easytest"
-using Easytest::DSL
+include Easytest::DSL
 
 test "should not run this case" do
   raise

--- a/test/fixtures/show_case_results.rb
+++ b/test/fixtures/show_case_results.rb
@@ -1,5 +1,5 @@
 require "easytest"
-include Easytest::DSL
+extend Easytest::DSL
 
 test "passed" do
   expect(1).to_eq 1

--- a/test/fixtures/show_case_results.rb
+++ b/test/fixtures/show_case_results.rb
@@ -1,5 +1,5 @@
 require "easytest"
-using Easytest::DSL
+include Easytest::DSL
 
 test "passed" do
   expect(1).to_eq 1

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -1,6 +1,6 @@
 require "easytest"
 
-include Easytest::DSL
+extend Easytest::DSL
 
 test "simple case" do
   expect(1 + 2).to_eq 3

--- a/test/smoke_test.rb
+++ b/test/smoke_test.rb
@@ -1,6 +1,6 @@
 require "easytest"
 
-using Easytest::DSL
+include Easytest::DSL
 
 test "simple case" do
   expect(1 + 2).to_eq 3


### PR DESCRIPTION
When passing `true` as the second argument to `Kernel#load` like `load("...", true)`,
it's possible to execute a test script in the context of an anonymous module.

This way is safer than `load("...")` since it's possible to avoid any scope pollution.
