### PR TITLE
Fix type error for Listen gem

### DIFF
--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -13,3 +13,4 @@ gems:
     ignore: true
   - name: easytest
     ignore: true
+  - name: listen


### PR DESCRIPTION
```
+ lib/easytest/cli.rb:134:17: [warning] Cannot find the declaration of constant: `Listen`
+ │ Diagnostic ID: Ruby::UnknownConstant
+ │
+ └       listener = Listen.to(Easytest.test_dir, only: /_test\.rb$/) do |modified, added|
+                    ~~~~~~
```
