### PR TITLE
Run Ruby 2.7 on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,3 +8,5 @@ on:
 jobs:
   test:
     uses: ybiquitous/.github/.github/workflows/ruby-test-reusable.yml@main
+    with:
+      ruby-version: '["2.7", "3.0", "3.1", "3.2"]'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,4 +9,4 @@ jobs:
   test:
     uses: ybiquitous/.github/.github/workflows/ruby-test-reusable.yml@main
     with:
-      ruby-version: '["2.7", "3.0", "3.1", "3.2"]'
+      ruby-version: '["2.7", "3.0", "3.1", "3.2", "head"]'


### PR DESCRIPTION
`ruby/actions` has dropped Ruby 2.7 due to EOL, but this project supports Ruby 2.7 still.

Ref:
- https://github.com/ruby/actions/blob/cf3a31799796546281e6fe21ab4d2bd8e965caed/.github/workflows/ruby_versions.yml
- https://github.com/ybiquitous/easytest/blob/a4462cdefc4312407fa2f67b7fd411e549812f9d/easytest.gemspec#L13
