### PR TITLE
Drop support for Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,4 +9,4 @@ jobs:
   test:
     uses: ybiquitous/.github/.github/workflows/ruby-test-reusable.yml@main
     with:
-      minimum-ruby-version: 2.7
+      minimum-ruby-version: "3.0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,4 +9,4 @@ jobs:
   test:
     uses: ybiquitous/.github/.github/workflows/ruby-test-reusable.yml@main
     with:
-      minimum-ruby-version: "3.0"
+      minimum-ruby-version: 3.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: enable
   SuggestExtensions: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Head
 
-- **Breaking** Change refinement to `extend` in an anonymous module. The usage should change as follows:
+- **Breaking:** Change refinement to `extend` in an anonymous module. The usage should change as follows:
   ```diff
   -using Easytest::DSL
   +extend Easytest::DSL
   ```
-- **Breaking** Drop support for Ruby 2.7 (End-of-Life on March 31, 2023)
+- **Breaking:** Drop support for Ruby 2.7 (End-of-Life on March 31, 2023)
 - Remove extra whitespaces from console output.
 
 ## 0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Head
 
-- **[Breaking]** Change refinement to `extend` in an anonymous module. The usage should change as follows:
+- **Breaking** Change refinement to `extend` in an anonymous module. The usage should change as follows:
   ```diff
   -using Easytest::DSL
   +extend Easytest::DSL
   ```
+- **Breaking** Drop support for Ruby 2.7 (End-of-Life on March 31, 2023)
 - Remove extra whitespaces from console output.
 
 ## 0.9.0

--- a/easytest.gemspec
+++ b/easytest.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Easy testing for Ruby."
   spec.description = "Easytest is a tiny testing framework for Ruby with a familiar DSL."
   spec.homepage = "https://ybiquitous.github.io/easytest/"
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/ybiquitous/easytest"


### PR DESCRIPTION
Ruby 2.7 reached End-of-Life on March 31, 2023.
