### PR TITLE
Drop Ruby 3.0 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,4 +9,4 @@ jobs:
   test:
     uses: ybiquitous/.github/.github/workflows/ruby-test-reusable.yml@main
     with:
-      minimum-ruby-version: 3.0
+      minimum-ruby-version: 3.1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   NewCops: enable
   SuggestExtensions: false
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## Head
+
+- Drop Ruby 3.0 support due to EOL (April 2024).
+
 ## 0.10.1
 
 - No actual changes. Just switch to a new simplified release workflow.

--- a/easytest.gemspec
+++ b/easytest.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Easy testing for Ruby."
   spec.description = "Easytest is a tiny testing framework for Ruby with a familiar DSL."
   spec.homepage = "https://ybiquitous.github.io/easytest/"
-  spec.required_ruby_version = ">= 3.0"
+  spec.required_ruby_version = ">= 3.1"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/ybiquitous/easytest"

--- a/lib/easytest/dsl.rb
+++ b/lib/easytest/dsl.rb
@@ -23,8 +23,8 @@ module Easytest
       Easytest.add_case Case.new(name: name, only: true, block: block)
     end
 
-    def expect(actual = nil, &block)
-      Expectation.new(actual, &block)
+    def expect(actual = nil, &)
+      Expectation.new(actual, &)
     end
   end
 end

--- a/test/expectation_test.rb
+++ b/test/expectation_test.rb
@@ -160,8 +160,8 @@ test "not.to_satisfy" do
   expect { subject(2).not.to_satisfy { |n| n > 1 } }.to_raise "not satisfy"
 end
 
-def subject_block(&block)
-  Easytest::Expectation.new(nil, &block)
+def subject_block(&)
+  Easytest::Expectation.new(nil, &)
 end
 
 raise_thing = -> { raise "foo" }


### PR DESCRIPTION
Ruby 3.0 has reached EOL April 2024. See:
https://www.ruby-lang.org/en/downloads/branches/
