### PR TITLE
Set minimum Ruby version to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,7 @@ on:
 jobs:
   test:
     uses: ybiquitous/.github/.github/workflows/ruby-test-reusable.yml@f3aa9016849a3bebe447aa3e1ebee363742ab0be # v3.0.0
+    with:
+      minimum-ruby-version: "3.2" # sync with `required_ruby_version` in gemspec
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,6 @@ jobs:
   test:
     uses: ybiquitous/.github/.github/workflows/ruby-test-reusable.yml@f3aa9016849a3bebe447aa3e1ebee363742ab0be # v3.0.0
     with:
-      minimum-ruby-version: "3.2" # sync with `required_ruby_version` in gemspec
+      minimum-ruby-version: 3.2 # sync with `required_ruby_version` in gemspec
     permissions:
       contents: read


### PR DESCRIPTION
### Motivation / Background

Ruby 3.2 is now EOL, but the gemspec still requires it.

https://github.com/ybiquitous/easytest/blob/1b51628b6fb8b166157e4172074105c88e71b48d/easytest.gemspec#L13

### Checklist

Check all and take necessary actions when you open this pull request.
(These help auto-generation for release notes)

- [ ] Add the `enhancement` label if this adds a new feature.
- [ ] Add the `bug` label if this fixes a bug.
- [ ] Start the title with `[Breaking]` if this includes a breaking change.
